### PR TITLE
doc: get example page working, correct broken links

### DIFF
--- a/examples/index.jsx
+++ b/examples/index.jsx
@@ -1,24 +1,10 @@
-'use strict'
-var React = require('react');
+"use strict";
+var React = require("react");
+var ReactDOM = require("react-dom");
 
-var Home = require('./views/home/index.jsx');
+var Home = require("./views/home/index.jsx");
 
-require('normalize.css/normalize.css');
-require('./app.css');
+require("normalize.css/normalize.css");
+require("./app.css");
 
-var App = React.createClass({
-  render: function () {
-    return (
-      <div className="App">
-        <header className="App-header">
-        </header>
-
-        <div className="App-content">
-          <Home />
-        </div>
-      </div>
-    );
-  }
-});
-
-React.render(<App />, document.body);
+ReactDOM.render(<Home />, document.getElementById("App"));

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "James Coleman",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/siganvio/react-scrollbars/issues"
+    "url": "https://github.com/signavio/react-scrollbars/issues"
   },
-  "homepage": "https://github.com/siganvio/react-scrollbars",
+  "homepage": "https://github.com/signavio/react-scrollbars",
   "devDependencies": {
     "autoprefixer-loader": "^1.0.0",
     "babel": "^5.8.29",
@@ -47,5 +47,9 @@
   "peerDependencies": {
     "react": "^15.0.1 || ^16.0.0",
     "react-dom": "^15.0.1 || ^16.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/signavio/react-scrollbars.git"
   }
 }

--- a/src/components/scrollbar-wrapper.jsx
+++ b/src/components/scrollbar-wrapper.jsx
@@ -36,20 +36,20 @@ function scrollTop() {
 var ScrollbarWrapper = createClass({
   mixins: [ScrollbarMixin],
 
-  componentDidMount: function() {
+  componentDidMount: function () {
     window.addEventListener("message", this.handleReceive, false);
     window.addEventListener("scroll", this.handleWindowScroll, false);
     window.addEventListener("resize", this.handleWindowScroll, false);
     this.handleWindowScroll();
   },
 
-  componentWillUnmount: function() {
+  componentWillUnmount: function () {
     window.removeEventListener("message", this.handleReceive, false);
     window.removeEventListener("scroll", this.handleWindowScroll, false);
     window.removeEventListener("resize", this.handleWindowScroll, false);
   },
 
-  handleReceive: function(event) {
+  handleReceive: function (event) {
     var data = event.data;
 
     if (typeof this[data.func] === "function") {
@@ -57,19 +57,19 @@ var ScrollbarWrapper = createClass({
     }
   },
 
-  handleWindowScroll: function(event) {
+  handleWindowScroll: function (event) {
     if (this.props.scrollbarAffix) {
       this.setState({
-        fixedScrollbar: this.isPartiallyVisible()
+        fixedScrollbar: this.isPartiallyVisible(),
       });
     }
   },
 
-  onResize: function() {
+  onResize: function () {
     this.handleContentResize();
   },
 
-  render: function() {
+  render: function () {
     return (
       <div
         style={this.scrollbarContainerStyle()}
@@ -85,7 +85,7 @@ var ScrollbarWrapper = createClass({
             className="ScrollbarChildren"
             style={{
               position: "relative",
-              paddingBottom: this.state.nativeScrollbarWidth
+              paddingBottom: this.state.nativeScrollbarWidth,
             }}
           >
             {this.props.children}
@@ -96,7 +96,7 @@ var ScrollbarWrapper = createClass({
                 height: "100%",
                 position: "absolute",
                 top: "-100%",
-                left: "-100%"
+                left: "-100%",
               }}
               frameBorder="0"
               src="javascript:window.onresize=function(){parent.postMessage({'func': 'onResize'}, '*')}"
@@ -110,7 +110,7 @@ var ScrollbarWrapper = createClass({
   },
 
   // returns true if parts, but not the bottom border, of the scroll container are visible in the current viewport
-  isPartiallyVisible: function() {
+  isPartiallyVisible: function () {
     var containerEl = ReactDOM.findDOMNode(this);
     var elTop = offsetTop(containerEl);
     var elBottom = elTop + containerEl.clientHeight;
@@ -119,7 +119,7 @@ var ScrollbarWrapper = createClass({
     var vpBottom = vpTop + viewportHeight();
 
     return elTop <= vpBottom && elBottom >= vpBottom;
-  }
+  },
 });
 
 module.exports = ScrollbarWrapper;


### PR DESCRIPTION
- No Issue


**Reason:**
React from version 0.14 onwards is split into two parts: React and ReactDOM. 
this is what happens if you don't pin your dependancies

First of many pull requests, get the example page running again
Plan is to use github pages and get it up 

Apologies for my editor config kicking in with the double quotes
